### PR TITLE
fix for N sp3 protonated?

### DIFF
--- a/meeko/hydrate.py
+++ b/meeko/hydrate.py
@@ -37,7 +37,8 @@ class HydrateMoleculeLegacy:
                            'NA': {
                                       1: (1, 1), # neigh: 1, wat: 3, sp1
                                       2: (1, 2), # neigh: 2, wat: 1, sp2
-                                      3: (1, 3)  # neigh: 3, wat: 1, sp3
+                                      3: (1, 3), # neigh: 3, wat: 1, sp3
+                                      4: (1, 3)  # fix for protonated N with neigh: 3, sp3. Also add 1 water 
                                   }
                            }
 


### PR DESCRIPTION
hydrated docking tutorial has error (tutorial example: https://autodock-vina.readthedocs.io/en/latest/docking_hydrated.html)
mk_prepare_ligand.py -i 1uw6_ligand.sdf -o 1uw6_ligand.pdbqt --pH 7.4 -w
.../site-packages/meeko/hydrate.py", line 144, in hydrate
    raise RuntimeError('Cannot place water molecules on atom %d of type %s with %d neighbors.' % (a, atom_type, len(neighbors)))
RuntimeError: Cannot place water molecules on atom 7 of type NA with 4 neighbors.